### PR TITLE
Updated name of test

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -27,7 +27,7 @@ describe('App Component', () => {
     });
   });
 
-  it('should contain Dashboard text', async(() => {
+  it('should not contain Dashboard text', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     expect(fixture.nativeElement).not.toContainText('Welcome to the Dashboard');


### PR DESCRIPTION
The name of the test is wrong. It is testing that the element does **not** contain "Welcome to the Dashboard", but the name says it is testing that it is in fact there.