### PR TITLE
use es5 supported Array.indexOf instead of es2016 Array.includes

### DIFF
--- a/src/app/reducers/index.ts
+++ b/src/app/reducers/index.ts
@@ -44,7 +44,7 @@ const resetOnLogout = (reducer: Function) => {
 };
 
 const DEV_REDUCERS = [stateSetter, storeFreeze];
-if (['logger', 'both'].includes(STORE_DEV_TOOLS)) { // set in constants.js file of project root
+if (['logger', 'both'].indexOf(STORE_DEV_TOOLS) !== -1 ) { // set in constants.js file of project root
     DEV_REDUCERS.push(storeLogger());
 }
 


### PR DESCRIPTION
Array.includes was causing problems for me when trying to start angular universal, with or without aot, with the following error:

```
> angular-webpack2-starter@1.14.0 server:universal /Users/mcosti/projects/non-ctct/angular-webpack2-starter
> nodemon dist/server/index.js

[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: /Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/**/*
[nodemon] starting `node dist/server/index.js`
/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1
(function (exports, require, module, __filename, __dirname) { module.exports=function(e){function t(r){if(n[r])return n[r].exports;var o=n[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,t),o.l=!0,o.exports}var n={},r={1:0};return t.e=function(t){if(0!==r[t]){var n=require("./"+t+".index.js"),o=n.modules,s=n.ids;for(var i in o)e[i]=o[i];for(var c=0;c<s.length;c++)r[s[c]]=0}return Promise.resolve()},t.m=e,t.c=n,t.i=function(e){return e},t.d=function(e,t,n){Object.defineProperty(e,t,{configurable:!1,enumerable:!0,get:n})},t.n=function(e){var n=e&&e.__esModule?function(){return e.default}:function(){return e};return t.d(n,"a",n),n},t.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},t.p="",t.oe=function(e){process.nextTick(function(){throw e})},t(t.s="./src/server.ts")}({"./constants.js":function(e,t,n){"use strict";const r=n("./helpers.js").root,o=n(38);t.HOST=o.address(),t.DEV_PORT=3e3,t.E2E_PORT=4

TypeError: ["logger","both"].includes is not a function
    at Object.module.exports.e../src/app/reducers/index.ts (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:11633)
    at t (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:177)
    at Object.module.exports.e../src/app/app.imports.ts (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:4940)
    at t (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:177)
    at Object.module.exports.e../src/app/app.module.universal.node.ts (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:5513)
    at t (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:177)
    at Object.<anonymous> (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:19266)
    at Object.module.exports.e../src/server.ts (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:20041)
    at t (/Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:177)
    at /Users/mcosti/projects/non-ctct/angular-webpack2-starter/dist/server/index.js:1:785
[nodemon] app crashed - waiting for file changes before starting...
```

It looks like [Array.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) is in the specification for ES-2016, and older versions of node will fail, as well as older browsers and all versions of IE.

