### PR TITLE
Fixed broken package.json, enabled es2015 modules for proper tree shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 /node_modules
 /bower_components
 npm-debug.log
+yarn.lock
 
 # Typing #
 /src/typings/tsd/

--- a/package.json
+++ b/package.json
@@ -102,12 +102,8 @@
     "@types/express": "~4.0.33",
     "@types/ip": "~0.0.29",
     "@types/jasmine": "~2.5.35",
-<<<<<<< HEAD
-    "@types/node": "~0.0.2",
-=======
     "@types/mime": "~0.0.29",
     "@types/node": "~6.0.52",
->>>>>>> a594ec9... update packages
     "@types/protractor": "~1.5.20",
     "@types/selenium-webdriver": "~2.44.29",
     "angular-router-loader": "~0.4.0",
@@ -131,7 +127,7 @@
     "karma-jasmine": "~1.0.2",
     "karma-mocha-reporter": "~2.2.0",
     "karma-phantomjs-launcher": "~1.0.2",
-    "karma-remap-coverage": "~0.1.1",
+    "karma-remap-coverage": "0.1.1",
     "karma-sourcemap-loader": "~0.3.7",
     "karma-webpack": "~1.8.0",
     "node-sass": "~3.13.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es5", "dom"],

--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -5,24 +5,19 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "noEmitHelpers": true,
-    "pretty": false,
-    "sourceMap": true,
     "lib": ["es5", "dom"],
-    "noEmit": true,
-    "strictNullChecks": false,
+    "noEmitHelpers": true,
     "skipDefaultLibCheck": true,
+    "pretty": true,
+    "sourceMap": true,
+    "strictNullChecks": false,
     "typeRoots": [
       "node_modules/@types"
     ]
   },
   "exclude": [
     "node_modules",
-    "src/compiled",
-    "src/**/*.e2e.ts",
-    "src/**/*.spec.ts",
-    "src/server.ts",
-    "src/main.browser.aot.ts"
+    "src/compiled"
   ],
   "awesomeTypescriptLoaderOptions": {
     "useWebpackText": true,
@@ -31,9 +26,5 @@
   },
   "compileOnSave": false,
   "buildOnSave": false,
-  "atom": { "rewriteTsconfig": false },
-  "angularCompilerOptions": {
-   "genDir": "src/compiled",
-   "skipMetadataEmit" : true
- }
+  "atom": { "rewriteTsconfig": false }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -116,7 +116,7 @@ const clientConfig = function webpackConfig(): WebpackConfig {
         test: /\.ts$/,
         loaders: [
           '@angularclass/hmr-loader',
-          'awesome-typescript-loader',
+          'awesome-typescript-loader?tsconfig=tsconfig.webpack.json',
           'angular2-template-loader',
           'angular-router-loader?loader=system&genDir=src/compiled/src/app&aot=' + AOT
         ],


### PR DESCRIPTION
Bugfixes for Bootstrap branch

1) Fixed incomplete rebase headers from package.json
2) `karma-remap-coverage` 1.1.3 is broken. Froze version to 1.1.1 until that is fixed.
3) Configured TypeScript to output ES2015 modules so Webpack can do proper tree shaking
4) Added `yarn.lock` to `.gitignore`