### PR TITLE
fix(package.json): #251 pin @types/jasmine to 2.5.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@types/express-serve-static-core": "~4.0.37",
     "@types/hammerjs": "~2.0.33",
     "@types/ip": "~0.0.29",
-    "@types/jasmine": "~2.5.35",
+    "@types/jasmine": "2.5.41",
     "@types/mime": "~0.0.29",
     "@types/node": "~6.0.52",
     "@types/selenium-webdriver": "~2.44.29",


### PR DESCRIPTION
Works around problem described in by pinning @types/jasmine https://github.com/qdouble/angular-webpack2-starter/issues/251