### PR TITLE
Added root('node_modules/@nguniversal') into EXCLUDE_SOURCE_MAPS

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -21,16 +21,16 @@ exports.DEV_SERVER_PROXY_CONFIG = {
 }
 
 /**
- * These constants set the source maps that will be used on build. 
- * For info on source map options, go to: 
+ * These constants set the source maps that will be used on build.
+ * For info on source map options, go to:
  * https://webpack.github.io/docs/configuration.html#devtool
  */
 exports.DEV_SOURCE_MAPS = 'eval';
 exports.PROD_SOURCE_MAPS = 'source-map';
 
 /**
- * Set watch options for Dev Server. For better HMR performance, you can 
- * try setting poll to 1000 or as low as 300 and set aggregateTimeout to as low as 0. 
+ * Set watch options for Dev Server. For better HMR performance, you can
+ * try setting poll to 1000 or as low as 300 and set aggregateTimeout to as low as 0.
  * These settings will effect CPU usage, so optimal setting will depend on your dev environment.
  * https://github.com/webpack/docs/wiki/webpack-dev-middleware#watchoptionsaggregatetimeout
  */
@@ -49,6 +49,7 @@ exports.STORE_DEV_TOOLS = 'monitor'
 exports.EXCLUDE_SOURCE_MAPS = [
   // these packages have problems with their sourcemaps
   root('node_modules/@angular'),
+  root('node_modules/@nguniversal'),
   root('node_modules/rxjs')
 ]
 


### PR DESCRIPTION
Fix for https://github.com/qdouble/angular-webpack2-starter/issues/288